### PR TITLE
Add todo list with pomodoro time tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +680,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1028,6 +1060,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,9 +1117,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "crossterm",
+ "dirs",
  "libc",
  "ratatui",
  "rodio",
+ "serde",
+ "serde_json",
  "stream-download",
  "tokio",
 ]
@@ -1434,6 +1479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,6 +1805,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +2016,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2287,7 +2362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2660,7 +2735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "atomic",
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2818,7 +2893,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "mac_address",
  "sha2",
  "thiserror 1.0.69",
@@ -3256,3 +3331,9 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ rodio = { version = "0.21.1", features = ["symphonia-mp3", "symphonia-aac"] }
 stream-download = { version = "0.23.0", features = ["reqwest-native-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+dirs = "6.0"

--- a/src/pomodoro.rs
+++ b/src/pomodoro.rs
@@ -26,7 +26,7 @@ impl Pomodoro {
         let break_len = Duration::from_secs(5 * 60);
 
         Self {
-            visible: false,
+            visible: true,
             running: false,
             mode: Mode::Focus,
             remaining: focus_len,
@@ -88,7 +88,7 @@ impl Pomodoro {
             let Ok(stream) = OutputStreamBuilder::open_default_stream() else {
                 return;
             };
-            let sink = Sink::connect_new(&stream.mixer());
+            let sink = Sink::connect_new(stream.mixer());
 
             // Different tones for focus vs break
             // Focus starting: lower, calming tone
@@ -106,8 +106,8 @@ impl Pomodoro {
                     .amplify(0.9);
                 sink.append(beep);
 
-                let silence = rodio::source::Zero::new(1, 44100)
-                    .take_duration(Duration::from_millis(150));
+                let silence =
+                    rodio::source::Zero::new(1, 44100).take_duration(Duration::from_millis(150));
                 sink.append(silence);
             }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,35 @@
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::todo::Task;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct TaskData {
+    pub tasks: Vec<Task>,
+    pub next_id: u64,
+}
+
+pub fn get_data_path() -> PathBuf {
+    let base = dirs::data_dir().unwrap_or_else(|| PathBuf::from("."));
+    base.join("loshell").join("tasks.json")
+}
+
+pub fn load_tasks() -> TaskData {
+    let path = get_data_path();
+    match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => TaskData::default(),
+    }
+}
+
+pub fn save_tasks(data: &TaskData) {
+    let path = get_data_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(data) {
+        let _ = fs::write(&path, json);
+    }
+}

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -1,0 +1,291 @@
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::storage::{self, TaskData};
+use crate::theme::Theme;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Task {
+    pub id: u64,
+    pub text: String,
+    pub completed: bool,
+    #[serde(default)]
+    pub time_spent_secs: u64,
+    pub created_at: u64,
+}
+
+impl Task {
+    pub fn new(id: u64, text: String) -> Self {
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        Self {
+            id,
+            text,
+            completed: false,
+            time_spent_secs: 0,
+            created_at,
+        }
+    }
+
+    pub fn format_time(&self) -> String {
+        if self.time_spent_secs == 0 {
+            return "--".to_string();
+        }
+        let hours = self.time_spent_secs / 3600;
+        let mins = (self.time_spent_secs % 3600) / 60;
+        format!("{}h {:02}m", hours, mins)
+    }
+}
+
+pub struct TodoList {
+    pub visible: bool,
+    pub tasks: Vec<Task>,
+    pub selected: usize,
+    pub input_mode: bool,
+    pub input_buffer: String,
+    pub active_task: Option<u64>,
+    next_id: u64,
+    last_save: Instant,
+}
+
+impl TodoList {
+    pub fn load() -> Self {
+        let data = storage::load_tasks();
+        Self {
+            visible: false,
+            tasks: data.tasks,
+            selected: 0,
+            input_mode: false,
+            input_buffer: String::new(),
+            active_task: None,
+            next_id: data.next_id.max(1),
+            last_save: Instant::now(),
+        }
+    }
+
+    pub fn save(&mut self) {
+        let data = TaskData {
+            tasks: self.tasks.clone(),
+            next_id: self.next_id,
+        };
+        storage::save_tasks(&data);
+        self.last_save = Instant::now();
+    }
+
+    pub fn save_throttled(&mut self) {
+        if self.last_save.elapsed() >= Duration::from_secs(60) {
+            self.save();
+        }
+    }
+
+    pub fn toggle_visible(&mut self) {
+        self.visible = !self.visible;
+        if !self.visible {
+            self.input_mode = false;
+            self.input_buffer.clear();
+        }
+    }
+
+    pub fn enter_input_mode(&mut self) {
+        self.input_mode = true;
+        self.input_buffer.clear();
+    }
+
+    pub fn cancel_input(&mut self) {
+        self.input_mode = false;
+        self.input_buffer.clear();
+    }
+
+    pub fn confirm_input(&mut self) {
+        if self.input_mode {
+            let text = self.input_buffer.trim().to_string();
+            if !text.is_empty() {
+                self.add_task(text);
+            }
+            self.input_mode = false;
+            self.input_buffer.clear();
+        }
+    }
+
+    pub fn add_task(&mut self, text: String) {
+        let task = Task::new(self.next_id, text);
+        self.next_id += 1;
+        self.tasks.push(task);
+        self.save();
+    }
+
+    pub fn delete_selected(&mut self) {
+        if self.tasks.is_empty() {
+            return;
+        }
+        let task_id = self.tasks[self.selected].id;
+        if self.active_task == Some(task_id) {
+            self.active_task = None;
+        }
+        self.tasks.remove(self.selected);
+        if self.selected >= self.tasks.len() && self.selected > 0 {
+            self.selected -= 1;
+        }
+        self.save();
+    }
+
+    pub fn toggle_completed(&mut self) {
+        if let Some(task) = self.tasks.get_mut(self.selected) {
+            task.completed = !task.completed;
+            self.save();
+        }
+    }
+
+    pub fn select_for_pomodoro(&mut self) {
+        if let Some(task) = self.tasks.get(self.selected) {
+            if self.active_task == Some(task.id) {
+                self.active_task = None;
+            } else {
+                self.active_task = Some(task.id);
+            }
+        }
+    }
+
+    pub fn add_time(&mut self, task_id: u64, duration: Duration) {
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id == task_id) {
+            task.time_spent_secs += duration.as_secs();
+        }
+    }
+
+    pub fn move_up(&mut self) {
+        if self.selected > 0 {
+            self.selected -= 1;
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        if !self.tasks.is_empty() && self.selected < self.tasks.len() - 1 {
+            self.selected += 1;
+        }
+    }
+
+    pub fn type_char(&mut self, c: char) {
+        if self.input_mode {
+            self.input_buffer.push(c);
+        }
+    }
+
+    pub fn backspace(&mut self) {
+        if self.input_mode {
+            self.input_buffer.pop();
+        }
+    }
+
+    pub fn draw(&self, f: &mut Frame, area: Rect) {
+        if !self.visible {
+            return;
+        }
+
+        let mut lines: Vec<Line> = Vec::new();
+
+        // Header
+        lines.push(Line::from(Span::styled(
+            "what stuff you have to ship today",
+            Theme::title(),
+        )));
+        lines.push(Line::from(""));
+
+        if self.tasks.is_empty() && !self.input_mode {
+            lines.push(Line::from(Span::styled(
+                "  nothing here. press n to add something.",
+                Theme::frame(),
+            )));
+        }
+
+        // Task list
+        for (i, task) in self.tasks.iter().enumerate() {
+            let is_selected = i == self.selected;
+            let is_active = self.active_task == Some(task.id);
+
+            let cursor = if is_selected { "> " } else { "  " };
+            let checkbox = if task.completed { "[x]" } else { "[ ]" };
+            let time_str = task.format_time();
+            let tracking = if is_active { " *" } else { "" };
+
+            // Calculate padding for right-aligned time
+            let text_len = task.text.chars().count();
+            let available = area.width.saturating_sub(16) as usize;
+            let text_display = if text_len > available {
+                format!("{}...", &task.text[..available.saturating_sub(3)])
+            } else {
+                task.text.clone()
+            };
+            let padding = available.saturating_sub(text_display.chars().count());
+
+            let text_style = if is_active {
+                Theme::accent()
+            } else if task.completed {
+                Theme::frame()
+            } else {
+                Theme::base()
+            };
+
+            let cursor_style = if is_selected {
+                Theme::accent()
+            } else {
+                Theme::base()
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(cursor, cursor_style),
+                Span::styled(format!("{} ", checkbox), Theme::frame()),
+                Span::styled(text_display, text_style),
+                Span::styled(tracking, Theme::accent()),
+                Span::raw(" ".repeat(padding.saturating_sub(tracking.len()))),
+                Span::styled(format!("{:>8}", time_str), Theme::frame()),
+            ]));
+        }
+
+        // Input line
+        if self.input_mode {
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("> ", Theme::accent()),
+                Span::styled(&self.input_buffer, Theme::base()),
+                Span::styled("_", Theme::accent()),
+            ]));
+        }
+
+        // Help bar
+        lines.push(Line::from(""));
+        if self.input_mode {
+            lines.push(Line::from(vec![
+                Span::styled("Enter ", Theme::accent()),
+                Span::styled("confirm  ", Theme::frame()),
+                Span::styled("Esc ", Theme::accent()),
+                Span::styled("cancel", Theme::frame()),
+            ]));
+        } else {
+            lines.push(Line::from(vec![
+                Span::styled("j/k ", Theme::accent()),
+                Span::styled("move  ", Theme::frame()),
+                Span::styled("n ", Theme::accent()),
+                Span::styled("new  ", Theme::frame()),
+                Span::styled("x ", Theme::accent()),
+                Span::styled("done  ", Theme::frame()),
+                Span::styled("d ", Theme::accent()),
+                Span::styled("del  ", Theme::frame()),
+                Span::styled("Enter ", Theme::accent()),
+                Span::styled("track", Theme::frame()),
+            ]));
+        }
+
+        let widget = Paragraph::new(lines).style(Theme::base());
+        f.render_widget(widget, area);
+    }
+}


### PR DESCRIPTION
## Summary

- Add todo list to center area with task management
- Track time per task when pomodoro is running
- Persist tasks to disk (~/.local/share/loshell/tasks.json on Linux, ~/Library/Application Support/loshell/tasks.json on macOS)
- Fix radio OutputStream drop message spam

## Keybindings

- `t` toggle todo panel
- `n` new task
- `j/k` navigate
- `x` mark done
- `d` delete
- `Enter` track task (link to pomodoro)
- `Space` auto-tracks selected task and starts timer

Closes #1