### PR TITLE
Add switchable themes

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::theme::ThemeName;
 use crate::todo::Task;
 
 #[derive(Serialize, Deserialize, Default)]
@@ -11,9 +12,31 @@ pub struct TaskData {
     pub next_id: u64,
 }
 
-pub fn get_data_path() -> PathBuf {
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub theme: ThemeName,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            theme: ThemeName::default(),
+        }
+    }
+}
+
+fn data_dir() -> PathBuf {
     let base = dirs::data_dir().unwrap_or_else(|| PathBuf::from("."));
-    base.join("loshell").join("tasks.json")
+    base.join("loshell")
+}
+
+pub fn get_data_path() -> PathBuf {
+    data_dir().join("tasks.json")
+}
+
+fn config_path() -> PathBuf {
+    data_dir().join("config.json")
 }
 
 pub fn load_tasks() -> TaskData {
@@ -30,6 +53,24 @@ pub fn save_tasks(data: &TaskData) {
         let _ = fs::create_dir_all(parent);
     }
     if let Ok(json) = serde_json::to_string_pretty(data) {
+        let _ = fs::write(&path, json);
+    }
+}
+
+pub fn load_config() -> Config {
+    let path = config_path();
+    match fs::read_to_string(&path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+        Err(_) => Config::default(),
+    }
+}
+
+pub fn save_config(config: &Config) {
+    let path = config_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(config) {
         let _ = fs::write(&path, json);
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,41 +1,159 @@
 use ratatui::style::{Color, Modifier, Style};
+use serde::{Deserialize, Serialize};
 
-// Loshell default pallete (bladerunner vibes)
-pub struct Theme;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ThemeName {
+    Bladerunner,
+    CatppuccinMocha,
+    Gruvbox,
+    TokyoNight,
+    RosePine,
+    Monotropic,
+}
+
+impl ThemeName {
+    pub const ALL: [ThemeName; 6] = [
+        ThemeName::Bladerunner,
+        ThemeName::CatppuccinMocha,
+        ThemeName::Gruvbox,
+        ThemeName::TokyoNight,
+        ThemeName::RosePine,
+        ThemeName::Monotropic,
+    ];
+
+    pub fn next(self) -> Self {
+        let idx = Self::ALL.iter().position(|&t| t == self).unwrap_or(0);
+        Self::ALL[(idx + 1) % Self::ALL.len()]
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ThemeName::Bladerunner => "Blade Runner",
+            ThemeName::CatppuccinMocha => "Catppuccin Mocha",
+            ThemeName::Gruvbox => "Gruvbox",
+            ThemeName::TokyoNight => "Tokyo Night",
+            ThemeName::RosePine => "Rosé Pine",
+            ThemeName::Monotropic => "Monotropic",
+        }
+    }
+}
+
+impl Default for ThemeName {
+    fn default() -> Self {
+        ThemeName::Bladerunner
+    }
+}
+
+pub struct Theme {
+    pub bg: Color,
+    pub fg: Color,
+    pub accent: Color,
+    pub secondary: Color,
+    pub hot: Color,
+    pub dim: Color,
+}
 
 impl Theme {
-    // core pallete
-    pub const BG: Color = Color::Rgb(0x0B, 0x0F, 0x1A); // midnight indigo
-    pub const FG: Color = Color::Rgb(0xAA, 0xB4, 0xD6); // soft grey-blue
-    pub const CYAN: Color = Color::Rgb(0x00, 0xF0, 0xFF); // neon cyan
-    pub const PURPLE: Color = Color::Rgb(0x6A, 0x5A, 0xCD); // muted purple
-    pub const PINK: Color = Color::Rgb(0xFF, 0x4F, 0xD8); // soft neon pink
-    pub const DIM: Color = Color::Rgb(0x4D, 0x56, 0x70); // subdued border/text
-
-    // Common styles
-    pub fn base() -> Style {
-        Style::default().fg(Self::FG).bg(Self::BG)
+    pub fn from_name(name: ThemeName) -> Self {
+        match name {
+            ThemeName::Bladerunner => Self::bladerunner(),
+            ThemeName::CatppuccinMocha => Self::catppuccin_mocha(),
+            ThemeName::Gruvbox => Self::gruvbox(),
+            ThemeName::TokyoNight => Self::tokyo_night(),
+            ThemeName::RosePine => Self::rose_pine(),
+            ThemeName::Monotropic => Self::monotropic(),
+        }
     }
 
-    pub fn frame() -> Style {
-        Style::default().fg(Self::DIM).bg(Self::BG)
+    fn bladerunner() -> Self {
+        Self {
+            bg: Color::Rgb(0x0B, 0x0F, 0x1A),
+            fg: Color::Rgb(0xAA, 0xB4, 0xD6),
+            accent: Color::Rgb(0x00, 0xF0, 0xFF),
+            secondary: Color::Rgb(0x6A, 0x5A, 0xCD),
+            hot: Color::Rgb(0xFF, 0x4F, 0xD8),
+            dim: Color::Rgb(0x4D, 0x56, 0x70),
+        }
     }
 
-    pub fn title() -> Style {
+    fn catppuccin_mocha() -> Self {
+        Self {
+            bg: Color::Rgb(0x1E, 0x1E, 0x2E),
+            fg: Color::Rgb(0xCD, 0xD6, 0xF4),
+            accent: Color::Rgb(0x89, 0xB4, 0xFA),
+            secondary: Color::Rgb(0xCB, 0xA6, 0xF7),
+            hot: Color::Rgb(0xF5, 0xC2, 0xE7),
+            dim: Color::Rgb(0x6C, 0x70, 0x86),
+        }
+    }
+
+    fn gruvbox() -> Self {
+        Self {
+            bg: Color::Rgb(0x28, 0x28, 0x28),
+            fg: Color::Rgb(0xEB, 0xDB, 0xB2),
+            accent: Color::Rgb(0x83, 0xA5, 0x98),
+            secondary: Color::Rgb(0xD3, 0x86, 0x9B),
+            hot: Color::Rgb(0xFE, 0x80, 0x19),
+            dim: Color::Rgb(0x92, 0x83, 0x74),
+        }
+    }
+
+    fn tokyo_night() -> Self {
+        Self {
+            bg: Color::Rgb(0x1A, 0x1B, 0x26),
+            fg: Color::Rgb(0xA9, 0xB1, 0xD6),
+            accent: Color::Rgb(0x7A, 0xA2, 0xF7),
+            secondary: Color::Rgb(0xBB, 0x9A, 0xF7),
+            hot: Color::Rgb(0xFF, 0x75, 0x7F),
+            dim: Color::Rgb(0x56, 0x5F, 0x89),
+        }
+    }
+
+    fn rose_pine() -> Self {
+        Self {
+            bg: Color::Rgb(0x19, 0x17, 0x24),
+            fg: Color::Rgb(0xE0, 0xDE, 0xF4),
+            accent: Color::Rgb(0x31, 0x74, 0x8F),
+            secondary: Color::Rgb(0xC4, 0xA7, 0xE7),
+            hot: Color::Rgb(0xEB, 0xBB, 0xBA),
+            dim: Color::Rgb(0x6E, 0x6A, 0x86),
+        }
+    }
+
+    fn monotropic() -> Self {
+        Self {
+            bg: Color::Rgb(0xFF, 0xFF, 0xFA),
+            fg: Color::Rgb(0x11, 0x11, 0x11),
+            accent: Color::Rgb(0x59, 0x3E, 0x2C),
+            secondary: Color::Rgb(0x74, 0x5B, 0x4B),
+            hot: Color::Rgb(0x8F, 0x79, 0x6C),
+            dim: Color::Rgb(0xAA, 0x99, 0x8E),
+        }
+    }
+
+    pub fn base(&self) -> Style {
+        Style::default().fg(self.fg).bg(self.bg)
+    }
+
+    pub fn frame(&self) -> Style {
+        Style::default().fg(self.dim).bg(self.bg)
+    }
+
+    pub fn title(&self) -> Style {
         Style::default()
-            .fg(Self::PURPLE)
-            .bg(Self::BG)
+            .fg(self.secondary)
+            .bg(self.bg)
             .add_modifier(Modifier::BOLD)
     }
 
-    pub fn accent() -> Style {
-        Style::default().fg(Self::CYAN).bg(Self::BG)
+    pub fn accent(&self) -> Style {
+        Style::default().fg(self.accent).bg(self.bg)
     }
 
-    pub fn hot() -> Style {
+    pub fn hot(&self) -> Style {
         Style::default()
-            .fg(Self::PINK)
-            .bg(Self::BG)
+            .fg(self.hot)
+            .bg(self.bg)
             .add_modifier(Modifier::BOLD)
     }
 }

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -186,7 +186,7 @@ impl TodoList {
         }
     }
 
-    pub fn draw(&self, f: &mut Frame, area: Rect) {
+    pub fn draw(&self, f: &mut Frame, area: Rect, theme: &Theme) {
         if !self.visible {
             return;
         }
@@ -196,14 +196,14 @@ impl TodoList {
         // Header
         lines.push(Line::from(Span::styled(
             "what stuff you have to ship today",
-            Theme::title(),
+            theme.title(),
         )));
         lines.push(Line::from(""));
 
         if self.tasks.is_empty() && !self.input_mode {
             lines.push(Line::from(Span::styled(
                 "  nothing here. press n to add something.",
-                Theme::frame(),
+                theme.frame(),
             )));
         }
 
@@ -228,26 +228,26 @@ impl TodoList {
             let padding = available.saturating_sub(text_display.chars().count());
 
             let text_style = if is_active {
-                Theme::accent()
+                theme.accent()
             } else if task.completed {
-                Theme::frame()
+                theme.frame()
             } else {
-                Theme::base()
+                theme.base()
             };
 
             let cursor_style = if is_selected {
-                Theme::accent()
+                theme.accent()
             } else {
-                Theme::base()
+                theme.base()
             };
 
             lines.push(Line::from(vec![
                 Span::styled(cursor, cursor_style),
-                Span::styled(format!("{} ", checkbox), Theme::frame()),
+                Span::styled(format!("{} ", checkbox), theme.frame()),
                 Span::styled(text_display, text_style),
-                Span::styled(tracking, Theme::accent()),
+                Span::styled(tracking, theme.accent()),
                 Span::raw(" ".repeat(padding.saturating_sub(tracking.len()))),
-                Span::styled(format!("{:>8}", time_str), Theme::frame()),
+                Span::styled(format!("{:>8}", time_str), theme.frame()),
             ]));
         }
 
@@ -255,9 +255,9 @@ impl TodoList {
         if self.input_mode {
             lines.push(Line::from(""));
             lines.push(Line::from(vec![
-                Span::styled("> ", Theme::accent()),
-                Span::styled(&self.input_buffer, Theme::base()),
-                Span::styled("_", Theme::accent()),
+                Span::styled("> ", theme.accent()),
+                Span::styled(&self.input_buffer, theme.base()),
+                Span::styled("_", theme.accent()),
             ]));
         }
 
@@ -265,27 +265,27 @@ impl TodoList {
         lines.push(Line::from(""));
         if self.input_mode {
             lines.push(Line::from(vec![
-                Span::styled("Enter ", Theme::accent()),
-                Span::styled("confirm  ", Theme::frame()),
-                Span::styled("Esc ", Theme::accent()),
-                Span::styled("cancel", Theme::frame()),
+                Span::styled("Enter ", theme.accent()),
+                Span::styled("confirm  ", theme.frame()),
+                Span::styled("Esc ", theme.accent()),
+                Span::styled("cancel", theme.frame()),
             ]));
         } else {
             lines.push(Line::from(vec![
-                Span::styled("j/k ", Theme::accent()),
-                Span::styled("move  ", Theme::frame()),
-                Span::styled("n ", Theme::accent()),
-                Span::styled("new  ", Theme::frame()),
-                Span::styled("x ", Theme::accent()),
-                Span::styled("done  ", Theme::frame()),
-                Span::styled("d ", Theme::accent()),
-                Span::styled("del  ", Theme::frame()),
-                Span::styled("Enter ", Theme::accent()),
-                Span::styled("track", Theme::frame()),
+                Span::styled("j/k ", theme.accent()),
+                Span::styled("move  ", theme.frame()),
+                Span::styled("n ", theme.accent()),
+                Span::styled("new  ", theme.frame()),
+                Span::styled("x ", theme.accent()),
+                Span::styled("done  ", theme.frame()),
+                Span::styled("d ", theme.accent()),
+                Span::styled("del  ", theme.frame()),
+                Span::styled("Enter ", theme.accent()),
+                Span::styled("track", theme.frame()),
             ]));
         }
 
-        let widget = Paragraph::new(lines).style(Theme::base());
+        let widget = Paragraph::new(lines).style(theme.base());
         f.render_widget(widget, area);
     }
 }

--- a/src/ui/logo.rs
+++ b/src/ui/logo.rs
@@ -3,18 +3,21 @@ use ratatui::{
     widgets::Paragraph,
 };
 
-use crate::theme::Theme;
+use crate::theme::{Theme, ThemeName};
 
-pub fn logo() -> Paragraph<'static> {
+pub fn logo<'a>(theme: &Theme, theme_name: ThemeName) -> Paragraph<'a> {
     let line = Line::from(vec![
-        Span::styled("▌", Theme::hot()),
-        Span::styled("LOSHELL", Theme::hot()),
-        Span::styled(" - ", Theme::base()),
-        Span::styled("A room for your mind", Theme::frame()),
+        Span::styled("▌", theme.hot()),
+        Span::styled("LOSHELL", theme.hot()),
+        Span::styled(" - ", theme.base()),
+        Span::styled("A room for your mind", theme.frame()),
+        Span::styled("  [", theme.frame()),
+        Span::styled(theme_name.label(), theme.accent()),
+        Span::styled("]", theme.frame()),
     ]);
 
-    Paragraph::new(line).style(Theme::base())
+    Paragraph::new(line).style(theme.base())
 }
 
-pub const LOGO_WIDTH: u16 = 32;
+pub const LOGO_WIDTH: u16 = 55;
 pub const LOGO_HEIGHT: u16 = 1;


### PR DESCRIPTION
## Summary

- Adds 6 switchable color themes: Blade Runner (default), Catppuccin Mocha, Gruvbox, Tokyo Night, Rosé Pine, and Monotropic
- Press `T` (shift-T) to cycle through themes at runtime
- Theme selection persists to `config.json` across app restarts
- Current theme name displayed in the logo bar

## Changes

- **theme.rs**: Rewrote from static unit struct to data struct with `ThemeName` enum and instance methods
- **storage.rs**: Added `Config` struct with `load_config()`/`save_config()` using existing persistence patterns
- **lib.rs**: Wired theme loading, `T` keybinding in normal and todo-visible modes, help bar updated
- **todo.rs**: Updated `draw()` to accept `&Theme` parameter
- **ui/logo.rs**: Shows current theme name, accepts `&Theme` + `ThemeName` parameters

No new dependencies. Closes #6.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] Default Blade Runner theme looks identical to current
- [x] `T` cycles through all 6 themes with instant visual feedback
- [x] Quit and relaunch preserves last selected theme
- [ ] Delete config.json falls back to Blade Runner