### PR TITLE
Add desktop notifications on pomodoro timer end

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,7 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
             }
 
             if pomo.tick_1s() {
+                pomo.notify();
                 pomo.play_notification();
                 // Restore volume after a delay (notification lasts ~1.5s)
                 let vol_handle = radio.volume_handle();

--- a/src/pomodoro.rs
+++ b/src/pomodoro.rs
@@ -82,6 +82,31 @@ impl Pomodoro {
         (secs / 60, secs % 60)
     }
 
+    pub fn notify(&self) {
+        let (title, body) = match self.mode {
+            Mode::Focus => ("Time to focus", "Focus session started. Let's go."),
+            Mode::Break => ("Take a break", "Break time. Step away for a bit."),
+        };
+        thread::spawn(move || {
+            #[cfg(target_os = "macos")]
+            {
+                let script = format!(
+                    "display notification \"{}\" with title \"{}\"",
+                    body, title
+                );
+                let _ = std::process::Command::new("osascript")
+                    .args(["-e", &script])
+                    .output();
+            }
+            #[cfg(target_os = "linux")]
+            {
+                let _ = std::process::Command::new("notify-send")
+                    .args([title, body])
+                    .output();
+            }
+        });
+    }
+
     pub fn play_notification(&self) {
         let is_focus = matches!(self.mode, Mode::Focus);
         thread::spawn(move || {


### PR DESCRIPTION
## Summary

- Fires native OS desktop notifications when the pomodoro timer switches between focus and break
- Uses `osascript` on macOS and `notify-send` on Linux -- zero new dependencies
- Notification fires before the sound beeps to avoid fd conflicts with rodio's stderr suppression

Closes #7.

## Test plan

- [ ] Start pomodoro, let timer run to completion -- desktop notification appears
- [ ] Both focus->break and break->focus transitions show distinct messages
- [ ] Sound beeps still play alongside notification