### PR TITLE
#12 feat: Addition of more stations

### DIFF
--- a/src/radio.rs
+++ b/src/radio.rs
@@ -37,6 +37,18 @@ pub const STATIONS: &[Station] = &[
         name: "Vaporwaves",
         url: "https://ice4.somafm.com/vaporwaves-128-mp3",
     },
+    Station {
+        name: "Chillits",
+        url: "https://ice4.somafm.com/chillits-128-mp3",
+    },
+    Station {
+        name: "Sonic Universe",
+        url: "https://ice4.somafm.com/sonicuniverse-128-mp3",
+    },
+    Station {
+        name: "Digitalis",
+        url: "https://ice4.somafm.com/digitalis-128-mp3",
+    },
 ];
 
 // Radio states


### PR DESCRIPTION
## Summary

It does de addition of 3 more options of stations from Soma FM:
-Chillits
-Sonic universe
-Digitalis


## Related Issues

Closes #12 

## Checklist

- [x] `cargo fmt` passes
- [ ] `cargo clippy` has no warnings
- [x] Tested locally
